### PR TITLE
Blank and null fields

### DIFF
--- a/djantic/fields.py
+++ b/djantic/fields.py
@@ -151,6 +151,9 @@ def ModelSchemaField(field: Any, schema_name: str) -> tuple:
         elif field.primary_key or blank or null:
             default = None
 
+        if default is not None and field.null:
+            python_type = Union[python_type, None]
+
         description = field.help_text
         title = field.verbose_name.title()
 

--- a/djantic/fields.py
+++ b/djantic/fields.py
@@ -1,12 +1,11 @@
 import logging
-from typing import Any, Dict, List, Union
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from datetime import date, time, datetime, timedelta
 from enum import Enum
+from typing import Any, Dict, Union
 from uuid import UUID
 
 from django.utils.functional import Promise
-
 from pydantic import IPvAnyAddress, Json
 from pydantic.fields import FieldInfo, Required, Undefined
 
@@ -46,7 +45,7 @@ FIELD_TYPES = {
     "FloatField": float,
     "UUIDField": UUID,
     "JSONField": Union[Json, dict, list],  # TODO: Configure this using default
-    "ArrayField": List,
+    "ArrayField": list,
     # "BigIntegerRangeField",
     # "CICharField",
     # "CIEmailField",
@@ -82,7 +81,7 @@ def ModelSchemaField(field: Any, schema_name: str) -> tuple:
 
         pk_type = FIELD_TYPES.get(internal_type, int)
         if field.one_to_many or field.many_to_many:
-            python_type = List[Dict[str, pk_type]]
+            python_type = list[Dict[str, pk_type]]
         else:
             python_type = pk_type
 

--- a/djantic/fields.py
+++ b/djantic/fields.py
@@ -95,6 +95,8 @@ def ModelSchemaField(field: Any, schema_name: str) -> tuple:
                 if Promise in type(v).__mro__:
                     v = str(v)
                 enum_choices[v] = k
+            if field.blank:
+                enum_choices['_blank'] = ''
 
             enum_prefix = (
                 f"{schema_name.replace('_', '')}{field.name.title().replace('_', '')}"

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -176,7 +176,7 @@ def test_enum_choices():
 
     assert PreferenceSchema.schema() == {
         "title": "PreferenceSchema",
-        "description": "Preference(id, name, preferred_food, preferred_group, preferred_sport)",
+        "description": "Preference(id, name, preferred_food, preferred_group, preferred_sport, preferred_musician)",
         "type": "object",
         "properties": {
             "id": {"title": "Id", "description": "id", "type": "integer"},
@@ -202,7 +202,13 @@ def test_enum_choices():
                 "title": "Preferred Sport",
                 "description": "preferred_sport",
                 "allOf": [{"$ref": "#/definitions/PreferenceSchemaPreferredSportEnum"}],
-            }
+            },
+            "preferred_musician": {
+                "allOf": [{"$ref": "#/definitions/PreferenceSchemaPreferredMusicianEnum"}],
+                'default': '',
+                "description": "preferred_musician",
+                "title": "Preferred Musician"
+            },
         },
         "required": ["name"],
         "definitions": {
@@ -220,17 +226,23 @@ def test_enum_choices():
                 "title": "PreferenceSchemaPreferredSportEnum",
                 "description": "An enumeration.",
                 "enum": ["football", "basketball", ""],
+            },
+            "PreferenceSchemaPreferredMusicianEnum": {
+                "title": "PreferenceSchemaPreferredMusicianEnum",
+                "description": "An enumeration.",
+                "enum": ["tom_jobim", "sinatra", ""],
             }
         },
     }
 
-    preference = Preference.objects.create(name="Jordan", preferred_sport="")
+    preference = Preference.objects.create(name="Jordan", preferred_sport="", preferred_musician=None)
     assert PreferenceSchema.from_django(preference).dict() == {
         "id": 1,
         "name": "Jordan",
         "preferred_food": "ba",
         "preferred_group": 1,
-        "preferred_sport": ""
+        "preferred_sport": "",
+        'preferred_musician': None
     }
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -176,7 +176,7 @@ def test_enum_choices():
 
     assert PreferenceSchema.schema() == {
         "title": "PreferenceSchema",
-        "description": "Preference(id, name, preferred_food, preferred_group)",
+        "description": "Preference(id, name, preferred_food, preferred_group, preferred_sport)",
         "type": "object",
         "properties": {
             "id": {"title": "Id", "description": "id", "type": "integer"},
@@ -198,6 +198,11 @@ def test_enum_choices():
                 "default": 1,
                 "allOf": [{"$ref": "#/definitions/PreferenceSchemaPreferredGroupEnum"}],
             },
+            "preferred_sport": {
+                "title": "Preferred Sport",
+                "description": "preferred_sport",
+                "allOf": [{"$ref": "#/definitions/PreferenceSchemaPreferredSportEnum"}],
+            }
         },
         "required": ["name"],
         "definitions": {
@@ -211,15 +216,21 @@ def test_enum_choices():
                 "description": "An enumeration.",
                 "enum": [1, 2],
             },
+            "PreferenceSchemaPreferredSportEnum": {
+                "title": "PreferenceSchemaPreferredSportEnum",
+                "description": "An enumeration.",
+                "enum": ["football", "basketball", ""],
+            }
         },
     }
 
-    preference = Preference.objects.create(name="Jordan")
+    preference = Preference.objects.create(name="Jordan", preferred_sport="")
     assert PreferenceSchema.from_django(preference).dict() == {
         "id": 1,
         "name": "Jordan",
         "preferred_food": "ba",
         "preferred_group": 1,
+        "preferred_sport": ""
     }
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -216,6 +216,11 @@ class GroupChoices(models.IntegerChoices):
     GROUP_2 = 2, "Second group"
 
 
+class SportChoices(models.TextChoices):
+    FOOTBALL = "football", _("I prefer to use my foots.")
+    BASKETBALL = "basketball", _("I prefer to use my hands.")
+
+
 class Preference(models.Model):
     name = models.CharField(max_length=128)
     preferred_food = models.CharField(
@@ -223,6 +228,9 @@ class Preference(models.Model):
     )
     preferred_group = models.IntegerField(
         choices=GroupChoices.choices, default=GroupChoices.GROUP_1
+    )
+    preferred_sport = models.CharField(
+        max_length=255, choices=SportChoices.choices, default=SportChoices.FOOTBALL, blank=True
     )
 
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -221,6 +221,11 @@ class SportChoices(models.TextChoices):
     BASKETBALL = "basketball", _("I prefer to use my hands.")
 
 
+class MusicianChoices(models.TextChoices):
+    TOM = "tom_jobim", _("Antônio Carlos Jobim.")
+    SINATRA = "sinatra", _("Francis Albert Sinatra.")
+
+
 class Preference(models.Model):
     name = models.CharField(max_length=128)
     preferred_food = models.CharField(
@@ -231,6 +236,9 @@ class Preference(models.Model):
     )
     preferred_sport = models.CharField(
         max_length=255, choices=SportChoices.choices, default=SportChoices.FOOTBALL, blank=True
+    )
+    preferred_musician = models.CharField(
+        max_length=255, choices=MusicianChoices.choices, null=True, blank=True, default=""
     )
 
 


### PR DESCRIPTION
This PR, separated in 3 commits, aims to:
- Fix typing.py importing order.
- Add support for TextChoices fields with `blank=True`
- Add support for fields with `null=True` and default value defined